### PR TITLE
Fix 'reduce is not defined' error

### DIFF
--- a/chumpy/ch_ops.py
+++ b/chumpy/ch_ops.py
@@ -15,6 +15,7 @@ from copy import copy as copy_copy
 
 import numpy as np
 import scipy.sparse as sp
+from functools import reduce
 
 from . import ch
 from .utils import row, col


### PR DESCRIPTION
If you run chumpy.demo('optimization') under python 3.6.4, 

...
    dr2 = p.dr_wrt(wrt, profiler=profiler)
  File "/home/ycjung/.pyenv/versions/flame3/lib/python3.6/site-packages/chumpy-0.67.5-py3.6.egg/chumpy/ch.py", line 777, in dr_wrt
    dr2 = p.dr_wrt(wrt, profiler=profiler)
  File "/home/ycjung/.pyenv/versions/flame3/lib/python3.6/site-packages/chumpy-0.67.5-py3.6.egg/chumpy/ch.py", line 777, in dr_wrt
    dr2 = p.dr_wrt(wrt, profiler=profiler)
  File "/home/ycjung/.pyenv/versions/flame3/lib/python3.6/site-packages/chumpy-0.67.5-py3.6.egg/chumpy/ch.py", line 749, in dr_wrt
    direct_dr = self._compute_dr_wrt_sliced(wrt)
  File "/home/ycjung/.pyenv/versions/flame3/lib/python3.6/site-packages/chumpy-0.67.5-py3.6.egg/chumpy/ch.py", line 294, in _compute_dr_wrt_sliced
    result = self.compute_dr_wrt(wrt)
  File "/home/ycjung/.pyenv/versions/flame3/lib/python3.6/site-packages/chumpy-0.67.5-py3.6.egg/chumpy/ch_ops.py", line 672, in compute_dr_wrt
    data = reduce(lambda x, y: x + y, result).ravel()
NameError: name 'reduce' is not defined

pops up. This simple commit fixes this error.